### PR TITLE
Add pipeline, LLM integration and venv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A media processing and storage system with MinIO S3-compatible storage.
 
 ## Setup
 
+### Create a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
 ### Install Dependencies
 
 ```bash

--- a/api/main.py
+++ b/api/main.py
@@ -1,23 +1,54 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel
-import json, sqlite3, io, fitz
+import json, sqlite3, io, fitz, pathlib
+import faiss
+from sentence_transformers import SentenceTransformer
 from src.storage import download_pdf
+from .ollama_client import ollama_generate
 
 app = FastAPI()
+
+DATA_DIR = pathlib.Path("data")
+
+model = SentenceTransformer("all-MiniLM-L12-v2")
+index = faiss.read_index(str(DATA_DIR / "faiss.index"))
 
 class Query(BaseModel):
     question: str
     top_k:    int
 
 def dense_search(q: str, k: int):
-    # your existing FAISS lookup logic…
-    # returns list of {"doc_path": key, "loc":{…}, "score":float, "text": str}
-    raise NotImplementedError
+    """Return top-k passages using the FAISS index."""
+    emb = model.encode([q], normalize_embeddings=True)
+    scores, ids = index.search(emb, k)
+    con = sqlite3.connect(DATA_DIR / "meta.db")
+    cur = con.cursor()
+    results = []
+    for idx, score in zip(ids[0], scores[0]):
+        row = cur.execute(
+            "SELECT chunk_id, doc_path, loc, text FROM meta WHERE id=?",
+            (int(idx),),
+        ).fetchone()
+        if row:
+            results.append({
+                "chunk_id": row[0],
+                "doc_path": row[1],
+                "loc": json.loads(row[2]),
+                "text": row[3],
+                "score": float(score),
+            })
+    con.close()
+    return results
 
 def synthesize_answer(q: str, passages: list):
-    # your existing LLM synthesis call…
-    raise NotImplementedError
+    """Use Ollama to generate an answer from passages."""
+    context = "\n\n".join(p["text"] for p in passages)
+    prompt = (
+        "Answer the question using the context below.\n\n" + context +
+        f"\n\nQuestion: {q}\nAnswer:"
+    )
+    return ollama_generate(prompt)
 
 @app.post("/chat")
 def chat(q: Query):

--- a/highlight_utils.py
+++ b/highlight_utils.py
@@ -1,0 +1,13 @@
+import re, html
+
+def highlight_terms(query: str, text: str) -> str:
+    """Return HTML where query terms are wrapped in <mark>."""
+    if not query:
+        return html.escape(text)
+    terms = [re.escape(t) for t in query.split() if t]
+    if not terms:
+        return html.escape(text)
+    pattern = re.compile(r"(" + "|".join(terms) + r")", re.IGNORECASE)
+    def repl(match):
+        return f"<mark>{html.escape(match.group(0))}</mark>"
+    return pattern.sub(repl, html.escape(text))

--- a/run_script.sh
+++ b/run_script.sh
@@ -17,6 +17,11 @@ if [ ! -f "$SCRIPT_PATH" ]; then
     exit 1
 fi
 
+# Activate virtual environment if present
+if [ -f ".venv/bin/activate" ]; then
+    source .venv/bin/activate
+fi
+
 # Run the script with PYTHONPATH set to current directory
 echo "🚀 Running $SCRIPT_PATH with PYTHONPATH=."
-PYTHONPATH=. python "$SCRIPT_PATH" "$@" 
+PYTHONPATH=. python "$SCRIPT_PATH" "$@"

--- a/scripts/full_pipeline.py
+++ b/scripts/full_pipeline.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Run the entire MediaMind processing pipeline."""
+import runpy
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+def main():
+    # sync local data to S3
+    runpy.run_path(str(SCRIPT_DIR / 'sync_to_s3.py'))
+    # extract PDFs from S3
+    runpy.run_path(str(SCRIPT_DIR / 'extract_pdf.py'))
+    # enrich chunks with spaCy NER
+    runpy.run_path(str(SCRIPT_DIR / 'enrich_chunks.py'))
+    # build embeddings and FAISS index
+    runpy.run_path(str(SCRIPT_DIR / 'embed_index.py'))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement highlight utility for Streamlit UI
- integrate FAISS search and ollama synthesis in API
- activate virtualenv automatically in `run_script.sh`
- document venv setup in README
- add `scripts/full_pipeline.py` helper to run the entire pipeline

## Testing
- `PYTHONPATH=. python scripts/test_imports.py` *(fails: No module named 'yaml')*
- `PYTHONPATH=. python scripts/test_minio_connection.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a4b0f00dc8325a84a1e22dac6f20f