### PR TITLE
Add script to launch app stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ pip install -r requirements.txt
 or 
 
 pip install fastapi pydantic faiss-cpu numpy sentence-transformers requests PyMuPDF tqdm spacy streamlit uvicorn urllib3
+
+## Run the application
+
+Use the convenience script below to launch Ollama, the FastAPI server and the
+Streamlit UI in one go:
+
+```bash
+python scripts/run_app.py
+```
+
+Any existing instances of these processes will be terminated automatically so
+you don't need to clear the ports manually.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ or
 
 pip install fastapi pydantic faiss-cpu numpy sentence-transformers requests PyMuPDF tqdm spacy streamlit uvicorn urllib3
 
+To enable image OCR when extracting PDFs install the optional dependencies:
+
+```bash
+pip install pytesseract pillow
+```
+You also need the tesseract binary on your system (e.g. `apt install tesseract-ocr`).
+
 ## Run the application
 
 Use the convenience script below to launch Ollama, the FastAPI server and the

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ spacy
 streamlit
 uvicorn
 urllib3
+pytesseract
+pillow

--- a/scripts/extract_pdf.py
+++ b/scripts/extract_pdf.py
@@ -1,4 +1,12 @@
-import fitz, uuid, json, pathlib, tqdm
+import fitz, uuid, json, pathlib, tqdm, io, shutil
+from typing import List
+
+try:
+    import pytesseract
+    from PIL import Image
+except Exception:  # optional OCR dependencies may be missing
+    pytesseract = None
+    Image = None
 
 DATA_DIR = pathlib.Path("data")                  # adjust if needed
 PDF_DIR  = DATA_DIR / "raw" / "pdf"
@@ -12,14 +20,31 @@ for pdf in tqdm.tqdm(PDF_DIR.rglob("*.pdf"), desc="extract"):
         doc = fitz.open(pdf, filetype="pdf")     # strict=False by default
         if doc.needs_pass:
             raise ValueError("encrypted")
+
         for page_no, page in enumerate(doc, 1):
+            text = page.get_text()
+
+            # ── OCR images if pytesseract is available ──────────────────────
+            if pytesseract and Image and shutil.which("tesseract"):
+                for img in page.get_images(full=True):
+                    xref = img[0]
+                    base = doc.extract_image(xref)
+                    img_bytes = base.get("image")
+                    if img_bytes:
+                        try:
+                            im = Image.open(io.BytesIO(img_bytes))
+                            text += "\n" + pytesseract.image_to_string(im)
+                        except Exception:
+                            pass
+
             chunks.append({
                 "chunk_id": str(uuid.uuid4()),
                 "source"  : "pdf",
                 "doc_path": str(pdf),
                 "loc"     : {"page": page_no},
-                "text"    : page.get_text()
+                "text"    : text
             })
+
     except Exception as err:
         skipped.append((pdf.name, str(err)))
         continue
@@ -29,3 +54,6 @@ print(f"✅ saved {len(chunks):,} chunks  |  🚫 skipped {len(skipped)} PDFs")
 if skipped:
     json.dump(skipped, open(OUT_DIR / "skipped_pdfs.json", "w"))
     print("   → see processed/skipped_pdfs.json for details")
+
+if pytesseract is None or Image is None or not shutil.which("tesseract"):
+    print("ℹ️  Install 'pytesseract', 'Pillow' and the tesseract binary for OCR support")

--- a/scripts/run_app.py
+++ b/scripts/run_app.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Run MediaMind stack with one command.
+
+Starts Ollama (if installed), the FastAPI backend via uvicorn and the
+Streamlit UI. Any existing processes are terminated so ports do not
+need to be cleared manually.
+"""
+import subprocess
+import shutil
+import signal
+import time
+import sys
+
+
+DEVNULL = subprocess.DEVNULL
+
+
+def kill_process(pattern: str) -> None:
+    """Terminate processes matching the pattern using pkill."""
+    if shutil.which("pkill"):
+        subprocess.run(["pkill", "-f", pattern], stdout=DEVNULL, stderr=DEVNULL)
+
+
+def start(cmd: list[str]):
+    return subprocess.Popen(cmd)
+
+
+def main() -> None:
+    # Stop any previous runs
+    for pat in ("uvicorn", "streamlit run", "ollama serve"):
+        kill_process(pat)
+
+    processes = []
+
+    # Start Ollama server if available
+    if shutil.which("ollama"):
+        processes.append(start(["ollama", "serve"]))
+        time.sleep(2)
+    else:
+        print("⚠️  ollama not installed - skipping")
+
+    # Start FastAPI backend
+    processes.append(start(["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]))
+    time.sleep(2)
+
+    # Start Streamlit UI
+    processes.append(start(["streamlit", "run", "ui/app.py"]))
+
+    def shutdown(*args):
+        for p in processes:
+            p.terminate()
+        for p in processes:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    # Wait on Streamlit process
+    processes[-1].wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script `scripts/run_app.py` that starts Ollama, uvicorn and Streamlit
- document how to run the application using the new script

## Testing
- `python3 -m py_compile api/*.py scripts/run_app.py src/*.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687b6761cbd083259a2170c9f7fdfc67